### PR TITLE
Fixed coordinator node environment variable name in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Riak in Docker
 Jon Brisbin <jbrisbin@basho.com>
 
-This asciibuild footnote:[https://github.com/jbrisbin/asciibuild] file can be used to build a wide variety of variations of Docker containers for running a Riak cluster. It runs a single node per container instance and by setting the `CLUSTER_COORDINATOR` environment variable to the IP address of a "master" node (the primary or seed node of a cluster), subsequent containers can be automatically joined into a cluster.
+This asciibuild footnote:[https://github.com/jbrisbin/asciibuild] file can be used to build a wide variety of variations of Docker containers for running a Riak cluster. It runs a single node per container instance and by setting the `COORDINATOR_NODE` environment variable to the IP address of a "master" node (the primary or seed node of a cluster), subsequent containers can be automatically joined into a cluster.
 
 image:https://travis-ci.org/basho-labs/riak-docker.svg[link="https://travis-ci.org/basho-labs/riak-docker"]
 


### PR DESCRIPTION
This is a fix for the coordinator node environment variable incorrectly being called CLUSTER_COORDINATOR instead of COORDINATOR_NODE in the readme.
