### PR TITLE
Only creates bucket type if it does not already exist

### DIFF
--- a/poststart.d/02-bootstrap-datatypes.sh
+++ b/poststart.d/02-bootstrap-datatypes.sh
@@ -5,6 +5,8 @@ echo "Looking for datatypes in $SCHEMAS_DIR..."
 for f in $(find $SCHEMAS_DIR -name *.dt -print); do
   BUCKET_NAME=$(basename -s .dt $f)
   BUCKET_DT=$(cat $f)
-  $RIAK_ADMIN bucket-type create $BUCKET_NAME "{\"props\":{\"datatype\":\"$BUCKET_DT\"}}"
-  $RIAK_ADMIN bucket-type activate $BUCKET_NAME
+  if ! [ riak-admin bucket-type list | grep -q $BUCKET_NAME ] ; then
+    $RIAK_ADMIN bucket-type create $BUCKET_NAME "{\"props\":{\"datatype\":\"$BUCKET_DT\"}}"
+    $RIAK_ADMIN bucket-type activate $BUCKET_NAME
+  fi
 done


### PR DESCRIPTION
Bootstrap datatypes fails on restart or when the node has just joined a cluster since riak-admin bucket-type create fails if the bucket type already exists.

This fix only creates the bucket type if it does not already exist.