### PR TITLE
refactor: Update cluster join method

### DIFF
--- a/poststart.d/99-join-cluster.sh
+++ b/poststart.d/99-join-cluster.sh
@@ -4,5 +4,7 @@
 if [[ -z "$($RIAK_ADMIN cluster status | egrep $COORDINATOR_NODE_HOST)" && "$COORDINATOR_NODE_HOST" != "$HOST" ]]; then
   # Not already in this cluster, so join
   echo "Connecting to cluster coordinator $COORDINATOR_NODE"
-  curl -sSL $HOST:8098/admin/control/clusters/default/join/riak@$COORDINATOR_NODE_HOST
+  riak-admin cluster join $CLUSTER_NAME@$COORDINATOR_NODE
+  riak-admin cluster plan
+  riak-admin cluster commit
 fi


### PR DESCRIPTION
Current method of joining a cluster during poststart seems to be outdated (and ill-documented at this point..?).

There's a way to do this throught `riak-admin` that's already provided in your image:
```
~/w/c/b/riak-docker (master) $ docker run -it basho/riak-kv which riak-admin
/usr/sbin/riak-admin
```

We successfully use it at @rbkmoney [in our custom image](https://github.com/rbkmoney/image-riak-base/blob/master/files/poststart.d/99-join-cluster.sh#L12-L14).