### PR TITLE
fix: Force Erlang cookie perms

### DIFF
--- a/prestart.d/00-set-cookie-permissions.sh
+++ b/prestart.d/00-set-cookie-permissions.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Riak is sensitive to permissions on the erlang distribution cookie file.
+# The ERTS requires that the cookie permissions are always 0600.
+# In some environments, file permissions may change. For example, this
+# can happen in kubernetes if the `fsGroup` option is used.
+
+COOKIE_PATH="/var/lib/riak/.erlang.cookie"
+
+if [ -e "$COOKIE_PATH" ]; then
+    chmod 0600 "$COOKIE_PATH"
+fi


### PR DESCRIPTION
```sh
# Riak is sensitive to permissions on the erlang distribution cookie file.
# The ERTS requires that the cookie permissions are always 0600.
# In some environments, file permissions may change. For example, this
# can happen in kubernetes if the `fsGroup` option is used.
```

Co-authored-by: Andrey Fadeev <me@ciiol.net>